### PR TITLE
Don't crash if there's a missing face

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -84,8 +84,9 @@ def face_detect(images):
 	pady1, pady2, padx1, padx2 = args.pads
 	for rect, image in zip(predictions, images):
 		if rect is None:
-			cv2.imwrite('temp/faulty_frame.jpg', image) # check this frame where the face was not detected.
-			raise ValueError('Face not detected! Ensure the video contains a face in all the frames.')
+			#cv2.imwrite('temp/faulty_frame.jpg', image) # check this frame where the face was not detected.
+			#raise ValueError('Face not detected! Ensure the video contains a face in all the frames.')
+			rect = [0,0,4,4]  # hacky workaround for a missing face: just make it very small
 
 		y1 = max(0, rect[1] - pady1)
 		y2 = min(image.shape[0], rect[3] + pady2)


### PR DESCRIPTION
I tried this out and waited over an hour for face_detect() to run, only to have the program crash during actually applying the mels to the faces because of this exception.

This is my quick workaround that got the code to work for me on my sample.

A robust solution would be something more like: dropping the frame (which would mean having to drop the equivalent space from the mels too).