### PR TITLE
The file "s3fd.pth" will never load automatically

### DIFF
--- a/face_detection/detection/sfd/sfd_detector.py
+++ b/face_detection/detection/sfd/sfd_detector.py
@@ -18,7 +18,7 @@ class SFDDetector(FaceDetector):
         super(SFDDetector, self).__init__(device, verbose)
 
         # Initialise the face detector
-        if path_to_detector is None:
+        if not os.path.isfile(path_to_detector):
             model_weights = load_url(models_urls['s3fd'])
         else:
             model_weights = torch.load(path_to_detector)


### PR DESCRIPTION
We check if path_to_detector is None, but `path_to_detector` will never be None because he is hardcoded in method params.
Hence, the file will never be automatically downloaded. I suggest checking if such a file exists and if not, then load it via the "load_url" method.