### PR TITLE
Speed up the training with saving audios as Numpy arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ preprocessed_root (lrs2_preprocessed)
 |	├── Folders with five-digit numbered video IDs
 |	│   ├── *.jpg
 |	│   ├── audio.wav
+|	│   ├── audio.npy
 ```
 
 Train!

--- a/color_syncnet_train.py
+++ b/color_syncnet_train.py
@@ -108,10 +108,15 @@ class Dataset(object):
             if not all_read: continue
 
             try:
-                wavpath = join(vidname, "audio.wav")
-                wav = audio.load_wav(wavpath, hparams.sample_rate)
-
-                orig_mel = audio.melspectrogram(wav).T
+                orig_mel_path = join(vidname, "audio.npy")
+                if os.path.isfile(orig_mel_path):
+                    orig_mel = np.load(orig_mel_path)
+                else:
+                    wavpath = join(vidname, "audio.wav")
+                    wav = audio.load_wav(wavpath, hparams.sample_rate)
+                    
+                    orig_mel = audio.melspectrogram(wav).T
+                    np.save(orig_mel_path, orig_mel)
             except Exception as e:
                 continue
 

--- a/hq_wav2lip_train.py
+++ b/hq_wav2lip_train.py
@@ -137,10 +137,15 @@ class Dataset(object):
                 continue
 
             try:
-                wavpath = join(vidname, "audio.wav")
-                wav = audio.load_wav(wavpath, hparams.sample_rate)
-
-                orig_mel = audio.melspectrogram(wav).T
+                orig_mel_path = join(vidname, "audio.npy")
+                if os.path.isfile(orig_mel_path):
+                    orig_mel = np.load(orig_mel_path)
+                else:
+                    wavpath = join(vidname, "audio.wav")
+                    wav = audio.load_wav(wavpath, hparams.sample_rate)
+                    
+                    orig_mel = audio.melspectrogram(wav).T
+                    np.save(orig_mel_path, orig_mel)
             except Exception as e:
                 continue
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -78,6 +78,11 @@ def process_audio_file(vfile, args):
 	command = template.format(vfile, wavpath)
 	subprocess.call(command, shell=True)
 
+	orig_mel_path = path.join(fulldir, "audio.npy")
+	wav = audio.load_wav(wavpath, hp.sample_rate)
+	orig_mel = audio.melspectrogram(wav).T
+	np.save(orig_mel_path, orig_mel)
+
 	
 def mp_handler(job):
 	vfile, args, gpu_id = job

--- a/wav2lip_train.py
+++ b/wav2lip_train.py
@@ -135,10 +135,15 @@ class Dataset(object):
                 continue
 
             try:
-                wavpath = join(vidname, "audio.wav")
-                wav = audio.load_wav(wavpath, hparams.sample_rate)
-
-                orig_mel = audio.melspectrogram(wav).T
+                orig_mel_path = join(vidname, "audio.npy")
+                if os.path.isfile(orig_mel_path):
+                    orig_mel = np.load(orig_mel_path)
+                else:
+                    wavpath = join(vidname, "audio.wav")
+                    wav = audio.load_wav(wavpath, hparams.sample_rate)
+                    
+                    orig_mel = audio.melspectrogram(wav).T
+                    np.save(orig_mel_path, orig_mel)
             except Exception as e:
                 continue
 


### PR DESCRIPTION
Training can be easily speed up by using numpy arrays instead of the `.wav` on each training step. `.wav` loading is very slow.
This pull request supports both `.npy` files creating in `preprocessing.py` and `.npy` creation on the fly for those datasets that were already preprocessed.
Inspired by https://github.com/Rudrabha/Wav2Lip/pull/265 and @primepake recommendation (https://github.com/primepake/wav2lip_288x288/issues/19#issuecomment-1141416549)