### PR TITLE
updated the eval code for small videos

### DIFF
--- a/evaluation/scores_LSE/calculate_scores_real_videos.sh
+++ b/evaluation/scores_LSE/calculate_scores_real_videos.sh
@@ -3,6 +3,6 @@ yourfilenames=`ls $1`
 
 for eachfile in $yourfilenames
 do
-   python run_pipeline.py --videofile $1/$eachfile --reference wav2lip --data_dir tmp_dir
+   python run_pipeline.py --videofile $1/$eachfile --reference wav2lip --data_dir tmp_dir --min_track 25
    python calculate_scores_real_videos.py --videofile $1/$eachfile --reference wav2lip --data_dir tmp_dir >> all_scores.txt
 done


### PR DESCRIPTION
The argument min_track [here](https://github.com/joonson/syncnet_python/blob/6efbb1c305c23f47a62b09cf4215a8ac45e97d49/run_pipeline.py#L30) sets the minimum number of frames required equal to 100, So perhaps it won't return metrics for videos less than say 4-sec.