### PR TITLE
Fix issue with keyword arguments

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -97,7 +97,7 @@ def _linear_to_mel(spectogram):
 
 def _build_mel_basis():
     assert hp.fmax <= hp.sample_rate // 2
-    return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels,
+    return librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels,
                                fmin=hp.fmin, fmax=hp.fmax)
 
 def _amp_to_db(x):


### PR DESCRIPTION
Recently on the colab notebooks I and several others have been getting

`Traceback (most recent call last):
  File "/content/Wav2Lip/inference.py", line 280, in <module>
    main()
  File "/content/Wav2Lip/inference.py", line 225, in main
    mel = audio.melspectrogram(wav)
  File "/content/Wav2Lip/audio.py", line 47, in melspectrogram
    S = _amp_to_db(_linear_to_mel(np.abs(D))) - hp.ref_level_db
  File "/content/Wav2Lip/audio.py", line 95, in _linear_to_mel
    _mel_basis = _build_mel_basis()
  File "/content/Wav2Lip/audio.py", line 100, in _build_mel_basis
    return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels,
TypeError: mel() takes 0 positional arguments but 2 positional arguments (and 3 keyword-only arguments) were given`

This seems to fix that problem and also should makes the project compatible with newer versions of librosa.