### PR TITLE
Wav2Lip_renew_requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa==0.7.0
 numpy==1.17.1
 opencv-contrib-python>=4.2.0.34
-opencv-python==4.1.0.25
+opencv-python==4.5.5.64
 torch==1.1.0
 torchvision==0.3.0
 tqdm==4.45.0


### PR DESCRIPTION
when running the project on colab and server, there are some problem caused by opencv-python module because of the ’opencv-python==4.1.0.25‘ in the requirement.txt while 'opencv-python==4.5.5.64' is totally fine.