### PR TITLE
fix macos install requirements error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 librosa==0.7.0
 numpy==1.17.1
-opencv-contrib-python>=4.2.0.34
+opencv-contrib-python==4.5.3.56
 opencv-python==4.1.0.25
 torch==1.1.0
 torchvision==0.3.0


### PR DESCRIPTION
When install the project dependencies on MacOS 10.15.7,  there is a error  for  install  `opencv-contrib-python ` :
```python
Traceback (most recent call last):
    File "/usr/local/anaconda3/envs/test_env/lib/python3.6/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/usr/local/anaconda3/envs/test_env/lib/python3.6/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/usr/local/anaconda3/envs/test_env/lib/python3.6/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 262, in build_wheel
      metadata_directory)
    File "/private/var/folders/s8/3w_b9gw976748lkd03_kgfxw0000gp/T/pip-build-env-l5muahcr/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 231, in build_wheel
      wheel_directory, config_settings)
    File "/private/var/folders/s8/3w_b9gw976748lkd03_kgfxw0000gp/T/pip-build-env-l5muahcr/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 215, in _build_with_temp_dir
      self.run_setup()
    File "/private/var/folders/s8/3w_b9gw976748lkd03_kgfxw0000gp/T/pip-build-env-l5muahcr/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 268, in run_setup
      self).run_setup(setup_script=setup_script)
    File "/private/var/folders/s8/3w_b9gw976748lkd03_kgfxw0000gp/T/pip-build-env-l5muahcr/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 532, in <module>
      main()
    File "setup.py", line 306, in main
      cmake_source_dir=cmake_source_dir,
    File "/private/var/folders/s8/3w_b9gw976748lkd03_kgfxw0000gp/T/pip-build-env-l5muahcr/overlay/lib/python3.6/site-packages/skbuild/setuptools_wrap.py", line 683, in setup
      cmake_install_dir,
    File "setup.py", line 445, in _classify_installed_files_override
      raise Exception("Not found: '%s'" % relpath_re)
  Exception: Not found: 'python/cv2/py.typed'
  Building wheel for opencv-contrib-python (pyproject.toml) ... error
  ERROR: Failed building wheel for opencv-contrib-python
Failed to build opencv-contrib-python
ERROR: Could not build wheels for opencv-contrib-python, which is required to install pyproject.toml-based projects
```

the detail can see :  https://github.com/opencv/opencv-python/issues/657 

and I try  https://github.com/opencv/opencv-python/issues/657#issuecomment-1313990224  . It works.

