### PR TITLE
increment the image counter AFTER checking that f is not None

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -59,9 +59,10 @@ def process_video_file(vfile, args, gpu_id):
 		preds = fa[gpu_id].get_detections_for_batch(np.asarray(fb))
 
 		for j, f in enumerate(preds):
-			i += 1
+			# increment the image counter AFTER checking that f is not None
 			if f is None:
 				continue
+			i += 1
 
 			x1, y1, x2, y2 = f
 			cv2.imwrite(path.join(fulldir, '{}.jpg'.format(i)), fb[j][y1:y2, x1:x2])


### PR DESCRIPTION
If the number `i` of the image is incremented before the test, there may be a jump in the image numbering.