### PR TITLE
Update audio.py (Fix TypeError in _build_mel_basis for compatibility with librosa >= 0.10.0)

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -97,7 +97,7 @@ def _linear_to_mel(spectogram):
 
 def _build_mel_basis():
     assert hp.fmax <= hp.sample_rate // 2
-    return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels,
+    return librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels, # sr and n_fft are now keyword args
                                fmin=hp.fmin, fmax=hp.fmax)
 
 def _amp_to_db(x):


### PR DESCRIPTION
This PR fixes a TypeError that occurs when initializing the audio processing module with newer versions of librosa (>= 0.10.0).

In modern librosa releases, the librosa.filters.mel function strictly enforces keyword-only arguments for sr and n_fft. Passing them as positional arguments—as previously implemented—causes an immediate crash in current Python environments.

Changes Made:
Updated _build_mel_basis in audio.py to explicitly pass sr=hp.sample_rate and n_fft=hp.n_fft as keyword arguments.

Impact:
This is a safe, non-breaking change. It stabilizes the environment for users running modern dependency stacks while remaining fully backward-compatible with older versions of librosa.